### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2.1
+jobs:
+  test:
+    parameters:
+        docker_image:
+          type: string
+          default: cimg/node:current
+    docker:
+      - image: << parameters.docker_image >>
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            rm -rf node_modules package-lock.json
+            npm install
+      - run:
+          name: Running all unit tests
+          command: |
+            node -v
+            npm -v
+            npm run test
+
+workflows:
+  version: 2
+  test-all-node-versions:
+    jobs:
+      - test:
+          docker_image: circleci/node:10-browsers
+      - test:
+          docker_image: cimg/node:12.13
+      - test:
+          docker_image: cimg/node:14.21
+      - test:
+          docker_image: cimg/node:16.19
+      - test:
+          docker_image: cimg/node:18.15
+      - test

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>nodeunit</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+	</natures>
+</projectDescription>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nodeunit",
-  "version": "0.11.3",
+  "name": "ilib-nodeunit",
+  "version": "0.11.4",
   "description": "Easy unit testing for node.js and the browser.",
   "maintainers": [
     {
@@ -58,13 +58,26 @@
       "web": "http://tmpvar.com"
     }
   ],
+  "files": [
+    "bin",
+    "doc",
+    "deps",
+    "examples",
+    "img",
+    "index.js",
+    "lib",
+    "LICENSE",
+    "man1",
+    "README.md",
+    "share"
+  ],
   "repository": {
     "type": "git",
     "url": "http://github.com/caolan/nodeunit.git"
   },
   "devDependencies": {
-    "should": ">=11.1.0",
-    "uglify-js": ">=2.7.3"
+    "should": ">=13.2.3",
+    "uglify-js": ">=3.17.4"
   },
   "bugs": {
     "url": "http://github.com/caolan/nodeunit/issues"
@@ -79,8 +92,8 @@
     "nodeunit": "./bin/nodeunit"
   },
   "dependencies": {
-    "ejs": "^2.5.2",
-    "tap": "^12.0.1"
+    "ejs": "^3.1.9",
+    "tap": "^16.3.8"
   },
   "scripts": {
     "test": "node ./bin/nodeunit"


### PR DESCRIPTION
- work around the @babel/types problem that has screwed up a huge number of things on npm
- this is a fork of nodeunit
- we need to move off of nodeunit and onto jest for the non-ilib projects that do not need to support qt